### PR TITLE
Updated fill_na_rows function in clean_data.py

### DIFF
--- a/quickda/clean_data.py
+++ b/quickda/clean_data.py
@@ -42,7 +42,7 @@ def fill_na_rows(data):
     # Retrieve the list of columns having nulls and interpolate for each column
     na_columns = df.columns[df.isna().any()].tolist()
     for column in na_columns:
-        df[column] = df[column].interpolate(method='pad', limit_direction='forward')
+        df[column] = df[column].interpolate(method='linear', limit_direction='both')
         
     return df
 


### PR DESCRIPTION
Changed interpolate **method** to **'linear'** and **limit_direction** to **'both'**

As with the **method='pad'** if index 0 value is NaN then this method won't will the index 0 value (it will remain NaN after interpolation also). Also with method='pad' we can't have **limit_direction='backward'**

It's better to choose **method='linear'** and **limit_direction='both'** (because there will be chances that first and last index values can be NaN, it will be easily interpolated if **limit_direction='both'**)